### PR TITLE
Update HOW_IT_WORKS.md - fixed backslash in windows path

### DIFF
--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -10,7 +10,7 @@
 
 app.getPath('userData') returns:
 - **Mac:** /Users/{username}/Library/Application Support/visual-backend
-- **Windows:** C:\Users\{username}\AppData\Roaming\visual-backend
+- **Windows:** C:\Users\\\{username}\AppData\Roaming\visual-backend
 
 ## Structure of Visual Backend
 


### PR DESCRIPTION
backslash is not displayed correctly - must use 3 to get it to display

This is shown in the image below:
![image](https://github.com/vbackend/visual-backend/assets/125736418/3cd98c15-e0c2-4da3-9f99-fd1b377da790)
